### PR TITLE
CLD-488: Update Helm Chart to use docker image scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.vscode
+values.yaml

--- a/charts/templates/configmap.yaml
+++ b/charts/templates/configmap.yaml
@@ -6,6 +6,6 @@ metadata:
   labels:
     {{- include "marklogic.labels" . | nindent 4 }}
 data:
-  ML_BOOTSTRAP_HOST: {{ include "marklogic.fullname" . }}-0
-  ML_FQDN_SUFFIX: {{ include "marklogic.headlessURL" . }}
+  MARKLOGIC_BOOTSTRAP_HOST: {{ include "marklogic.fullname" . }}-0
+  MARKLOGIC_FQDN_SUFFIX: {{ include "marklogic.headlessURL" . }}
   

--- a/charts/templates/configmap.yaml
+++ b/charts/templates/configmap.yaml
@@ -8,4 +8,5 @@ metadata:
 data:
   MARKLOGIC_BOOTSTRAP_HOST: {{ include "marklogic.fullname" . }}-0
   MARKLOGIC_FQDN_SUFFIX: {{ include "marklogic.headlessURL" . }}
-  
+  MARKLOGIC_INIT: "true"
+  MARKLOGIC_JOIN_CLUSTER: "true"

--- a/charts/templates/statefulset.yaml
+++ b/charts/templates/statefulset.yaml
@@ -41,8 +41,6 @@ spec:
                   secretKeyRef:
                     name: {{ include "marklogic.fullname" . }}
                     key: password
-            - name: MARKLOGIC_INIT
-              value: "true"
           envFrom:
             - configMapRef:
                 name: {{ include "marklogic.fullname" . }}

--- a/charts/templates/statefulset.yaml
+++ b/charts/templates/statefulset.yaml
@@ -48,12 +48,6 @@ spec:
           envFrom:
             - configMapRef:
                 name: {{ include "marklogic.fullname" . }}
-          command: 
-              - /bin/sh
-              - -c
-              - |
-                echo "====Running Start Marklogic Script";
-                sh /usr/local/bin/start-marklogic.sh;
           ports:
             - containerPort: 7997
               name: health-check

--- a/charts/templates/statefulset.yaml
+++ b/charts/templates/statefulset.yaml
@@ -31,83 +31,29 @@ spec:
               {{- toYaml .Values.extraVolumeMounts | nindent 12 }}
             {{- end }}
           env:
-            - name: ML_ADMIN_USER
+            - name: MARKLOGIC_ADMIN_USERNAME
               valueFrom:
                 secretKeyRef:
                   name: {{ include "marklogic.fullname" . }}
                   key: username
-            - name: ML_ADMIN_PASS
+            - name: MARKLOGIC_ADMIN_PASSWORD
               valueFrom:
                   secretKeyRef:
                     name: {{ include "marklogic.fullname" . }}
                     key: password
+            - name: MARKLOGIC_INIT
+              value: "true"
+            - name: REPLICA_COUNT
+              value: {{ .Values.replicaCount  | quote }}
           envFrom:
             - configMapRef:
                 name: {{ include "marklogic.fullname" . }}
-          command:
-            - bash
-            - '-c'
-            - |
-              echo '### Begin ML Container Config ###'
-
-              # Set Hostname to the value of hostname command to /etc/marklogic.conf
-              HOST_FQDN="$(hostname).$ML_FQDN_SUFFIX"
-              echo "export MARKLOGIC_HOSTNAME=\"$HOST_FQDN\"" | sudo tee /etc/marklogic.conf
-
-              cd ~
-
-              AUTH_CURL="curl --anyauth --user $ML_ADMIN_USER:$ML_ADMIN_PASS -m 20 -s "
-
-              # Start MarkLogic
-              sudo service MarkLogic start
-              sleep 5s
-
-              # Initialize and Setup Admin User
-              echo '### Initialize and Setup Admin User ###'
-              ML_STATUS_CODE=`curl -s -o /dev/null --write-out %{response_code}  http://localhost:8001/admin/v1/init`
-              if [ "$ML_STATUS_CODE" == "401" ]; then
-                echo "Server is already configured." 
-              else
-                curl -X POST -d "" http://$HOSTNAME:8001/admin/v1/init
-                sleep 5s
-
-                curl -X POST -H "Content-type: application/x-www-form-urlencoded" \
-                    --data "admin-username=$ML_ADMIN_USER" --data "admin-password=$ML_ADMIN_PASS" \
-                    --data "realm=public" \
-                    http://$HOSTNAME:8001/admin/v1/instance-admin
-                sleep 10s
-
-                # for EA1 release, disable turning on XDQP by default.
-                # Turn on XDQP encryption via CMA
-                # $AUTH_CURL -X POST -H 'Content-Type: application/json' \
-                #     -d '{"config":[{"op":"update","group":[{"group-name":"Default","xdqp-ssl-enabled":true}]}]}' \
-                #     http://$HOSTNAME:8002/manage/v3/
-
-                # Join Cluster
-                if [ "$HOSTNAME" != "$ML_BOOTSTRAP_HOST" ]; then
-                  echo "### joining cluster ###"
-                  joiner=$HOSTNAME
-                  cluster="$ML_BOOTSTRAP_HOST"
-                  $AUTH_CURL -o host.xml -X GET -H "Accept: application/xml" http://${joiner}:8001/admin/v1/server-config
-                  $AUTH_CURL -X POST -d "group=Default" --data-urlencode "server-config@./host.xml" -H "Content-type: application/x-www-form-urlencoded" -o cluster.zip http://${cluster}:8001/admin/v1/cluster-config
-
-                  sleep 10s
-
-                  $AUTH_CURL -X POST -H "Content-type: application/zip" --data-binary @./cluster.zip http://${joiner}:8001/admin/v1/cluster-config 
-                  sleep 5s
-
-                  rm -f host.xml
-                  rm -f cluster.zip
-                fi
-
-              fi
-
-              # mark the pod ready for readiness probe
-              sudo touch /var/opt/MarkLogic/ready
-
-              echo '### END ML Container Config ###'
-
-              tail -f $MARKLOGIC_DATA_DIR/Logs/ErrorLog.txt
+          command: 
+              - /bin/sh
+              - -c
+              - |
+                echo "====Running Start Marklogic Script";
+                sh /usr/local/bin/start-marklogic.sh;
           ports:
             - containerPort: 7997
               name: health-check

--- a/charts/templates/statefulset.yaml
+++ b/charts/templates/statefulset.yaml
@@ -43,19 +43,9 @@ spec:
                     key: password
             - name: MARKLOGIC_INIT
               value: "true"
-            - name: REPLICA_COUNT
-              value: {{ .Values.replicaCount  | quote }}
           envFrom:
             - configMapRef:
                 name: {{ include "marklogic.fullname" . }}
-          command: 
-              - /bin/sh
-              - -c
-              - |
-                echo "====Running Start Marklogic Script";
-                sh /usr/local/bin/start-marklogic.sh;
-                echo "====Running Start Marklogic Script Complete, Marking Pod as Ready";
-                sudo touch /var/opt/MarkLogic/ready;
           ports:
             - containerPort: 7997
               name: health-check

--- a/charts/templates/statefulset.yaml
+++ b/charts/templates/statefulset.yaml
@@ -48,6 +48,14 @@ spec:
           envFrom:
             - configMapRef:
                 name: {{ include "marklogic.fullname" . }}
+          command: 
+              - /bin/sh
+              - -c
+              - |
+                echo "====Running Start Marklogic Script";
+                sh /usr/local/bin/start-marklogic.sh;
+                echo "====Running Start Marklogic Script Complete, Marking Pod as Ready";
+                sudo touch /var/opt/MarkLogic/ready;
           ports:
             - containerPort: 7997
               name: health-check

--- a/docs/Local_Development_Tutorial.md
+++ b/docs/Local_Development_Tutorial.md
@@ -157,5 +157,3 @@ To cleanup a running kubernetes cluster, run the following commands:
   For Example:   
   `helm uninstall marklogic-local-dev-env`
 - `minikube delete`
-
-


### PR DESCRIPTION
Update statefulset.yml file to use the same env variables as the docker repo's scripts and update the command to run the start-marklogic script from the docker image instead of running a custom one. The changes to the docker script that needed to be made to make these changes work can be found here: https://github.com/marklogic/marklogic-docker/pull/86. 