### PR TITLE
CLD-620: Add warning if FQDN is over 64 characters

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@
   - [Notice](#notice)
 - [Uninstalling the Chart](#uninstalling-thechart)
 - [Parameters](#parameters)
+- [Known Issues and Limitations](#Known-Issues-and-Limitations)
+
 
 # Introduction
 
@@ -475,3 +477,7 @@ This table describes the list of available parameters for Helm Chart.
 | `logCollection.files.requestLogs`    | Enable this parameter to enable collection of Marklogics request logs when log collection is enabled           | `true`                               |
 | `logCollection.files.crashLogs`      | Enable this parameter to enable collection of Marklogics crash logs when log collection is enabled             | `true`                               |
 | `logCollection.files.auditLogs`      | Enable this parameter to enable collection of Marklogics audit logs when log collection is enabled             | `true`                               |
+
+# Known Issues and Limitations
+
+1. If the hostname is greater than 64 characters there may be issues with certificates. The certificates may shorten the name or use SANs for hostnames in the certificates.

--- a/charts/templates/NOTES.txt
+++ b/charts/templates/NOTES.txt
@@ -1,12 +1,13 @@
-{{- define "marklogic.fqdn" -}}
-{{- printf "%s-0.%s.%s.svc.cluster.local" (include "marklogic.fullname" .) (include "marklogic.headlessServiceName" .) .Release.Namespace }}
-{{- end}}
-
 Thank you for installing {{ .Chart.Name }}.
 
 Your release is named {{ .Release.Name }}.
 
 FQDN is {{ include "marklogic.fqdn" . }}
+{{- if gt (len (include "marklogic.fqdn" .)) 64 }}
+WARNING:    The hostname is greater than 64 characters
+            There may be issues with certificates
+            The certificates may shorten the name or use SANs for hostnames in the certificates
+{{- end }}
 
 Group {{ .Values.group.name }} is created on the MarkLogic cluster.
 

--- a/charts/templates/_helpers.tpl
+++ b/charts/templates/_helpers.tpl
@@ -75,3 +75,10 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Fully qualified domain name
+*/}}
+{{- define "marklogic.fqdn" -}}
+{{- printf "%s-0.%s.%s.svc.cluster.local" (include "marklogic.fullname" .) (include "marklogic.headlessServiceName" .) .Release.Namespace }}
+{{- end}}


### PR DESCRIPTION
Add known issues and limitations section to README Document this limitation in the known limitations section of the README Move FQDN declaration to _helpers.tpl so it is globally useable