### PR TITLE
CLD-767 Update test to match log message in Docker

### DIFF
--- a/test/e2e/admin_secrets_test.go
+++ b/test/e2e/admin_secrets_test.go
@@ -68,7 +68,7 @@ func TestMlAdminSecrets(t *testing.T) {
 	podLogs := k8s.GetPodLogs(t, kubectlOptions, pod, "")
 
 	// verify logs if wallet password is set as secret
-	if !strings.Contains(podLogs, "MARKLOGIC_WALLET_PASSWORD_FILE is set, using Docker secrets for wallet-password.") {
+	if !strings.Contains(podLogs, "MARKLOGIC_WALLET_PASSWORD_FILE is set, using file as secret for wallet-password.") {
 		t.Errorf("wallet password not set as secret")
 	}
 }


### PR DESCRIPTION
There was a mismatch between tests on K8s and Docker image log messages. This is causing the current pipeline failure.