### PR TITLE
CLD-952 Increase minikube memory

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -213,7 +213,7 @@ pipeline {
             }
             steps {
                 sh """
-                    export MINIKUBE_HOME=/space; export KUBECONFIG=/space/.kube-config; make test dockerImage=${dockerRepository}:${dockerVersion} prevDockerImage=${dockerRepository}:${prevDockerVersion} kubernetesVersion=${params.K8_VERSION} saveOutput=true
+                    export MINIKUBE_HOME=/space; export KUBECONFIG=/space/.kube-config; make test dockerImage=${dockerRepository}:${dockerVersion} prevDockerImage=${dockerRepository}:${prevDockerVersion} kubernetesVersion=${params.K8_VERSION} saveOutput=true minikubeMemory=20gb
                 """
             }
         }
@@ -223,7 +223,7 @@ pipeline {
             }
             steps {
                 sh """
-                    export MINIKUBE_HOME=/space; export KUBECONFIG=/space/.kube-config; make hc-test dockerImage=${dockerRepository}:${dockerVersion} kubernetesVersion=${params.K8_VERSION}
+                    export MINIKUBE_HOME=/space; export KUBECONFIG=/space/.kube-config; make hc-test dockerImage=${dockerRepository}:${dockerVersion} kubernetesVersion=${params.K8_VERSION} minikubeMemory=20gb
                 """
             }
         }

--- a/makefile
+++ b/makefile
@@ -1,6 +1,7 @@
 dockerImage?=ml-docker-db-dev-tierpoint.bed-artifactory.bedford.progress.com/marklogic/marklogic-server-centos:11.1.20230522-centos-1.0.2
 prevDockerImage?=ml-docker-db-dev-tierpoint.bed-artifactory.bedford.progress.com/marklogic/marklogic-server-centos:10.0-20230522-centos-1.0.2
 kubernetesVersion?=v1.25.8
+minikubeMemory?=10gb
 ## System requirement:
 ## - Go 
 ## 		- gotestsum (if you want to enable saveOutput for testing commands)
@@ -90,7 +91,7 @@ e2e-test: prepare
 	minikube delete
 
 	@echo "=====Installing minikube cluster"
-	minikube start --driver=docker --kubernetes-version=$(kubernetesVersion) -n=1 --memory=16000mb --cpus=2
+	minikube start --driver=docker --kubernetes-version=$(kubernetesVersion) -n=1 --memory=$(minikubeMemory) --cpus=2
 
 
 	@echo "=====Loading marklogc image $(dockerImage) to minikube cluster"
@@ -116,7 +117,7 @@ hc-test:
 	minikube delete
 
 	@echo "=====Installing minikube cluster"
-	minikube start --driver=docker --kubernetes-version=$(kubernetesVersion) -n=1 --memory=16000mb --cpus=2
+	minikube start --driver=docker --kubernetes-version=$(kubernetesVersion) -n=1 --memory=$(minikubeMemory) --cpus=2
 
 
 	@echo "=====Loading marklogc image $(dockerImage) to minikube cluster"


### PR DESCRIPTION
Also added makefile parameter in order to make it easier to run with less memory on dev machines. Minikube will use 20GB on Jenkins.