### PR TITLE
MLE-11779 fix cleanup and go context

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -234,7 +234,7 @@ pipeline {
                 docker system prune --force --filter "until=720h"
                 docker volume prune --force
                 docker image prune --force --all
-                rm -rf /space/.minikube /space/go /space/.kube-config
+                sudo rm -rf /space/.minikube /space/go /space/.kube-config
             '''
             sh "rm -rf $WORKSPACE/test/test_results/"
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -213,7 +213,7 @@ pipeline {
             }
             steps {
                 sh """
-                    export MINIKUBE_HOME=/space; export KUBECONFIG=/space/.kube-config; make test dockerImage=${dockerRepository}:${dockerVersion} prevDockerImage=${dockerRepository}:${prevDockerVersion} kubernetesVersion=${params.K8_VERSION} saveOutput=true minikubeMemory=20gb
+                    export MINIKUBE_HOME=/space; export KUBECONFIG=/space/.kube-config; export GOPATH=/space/go; make test dockerImage=${dockerRepository}:${dockerVersion} prevDockerImage=${dockerRepository}:${prevDockerVersion} kubernetesVersion=${params.K8_VERSION} saveOutput=true minikubeMemory=20gb
                 """
             }
         }
@@ -223,7 +223,7 @@ pipeline {
             }
             steps {
                 sh """
-                    export MINIKUBE_HOME=/space; export KUBECONFIG=/space/.kube-config; make hc-test dockerImage=${dockerRepository}:${dockerVersion} kubernetesVersion=${params.K8_VERSION} minikubeMemory=20gb
+                    export MINIKUBE_HOME=/space; export KUBECONFIG=/space/.kube-config; export GOPATH=/space/go; make hc-test dockerImage=${dockerRepository}:${dockerVersion} kubernetesVersion=${params.K8_VERSION} minikubeMemory=20gb
                 """
             }
         }
@@ -236,7 +236,7 @@ pipeline {
                 docker system prune --force --filter "until=720h"
                 docker volume prune --force
                 docker image prune --force --all
-                export MINIKUBE_HOME=/space; export KUBECONFIG=/space/.kube-config; minikube delete --all --purge
+                export MINIKUBE_HOME=/space; export KUBECONFIG=/space/.kube-config; export GOPATH=/space/go; minikube delete --all --purge
             '''
             sh "rm -rf $WORKSPACE/test/test_results/"
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -233,10 +233,11 @@ pipeline {
         always {
             publishTestResults()
             sh '''
+                export MINIKUBE_HOME=/space; export KUBECONFIG=/space/.kube-config; export GOPATH=/space/go; minikube delete --all --purge
                 docker system prune --force --filter "until=720h"
                 docker volume prune --force
                 docker image prune --force --all
-                export MINIKUBE_HOME=/space; export KUBECONFIG=/space/.kube-config; export GOPATH=/space/go; minikube delete --all --purge
+                rm -rf /space/.minikube /space/go /space/.kube-config
             '''
             sh "rm -rf $WORKSPACE/test/test_results/"
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -35,6 +35,9 @@ void preBuildCheck() {
             sh 'exit 1'
         }
     }
+
+    // our VMs sometime disable bridge traffic. this should help to restore it.
+    sh 'sudo sh -c "echo 1 > /proc/sys/net/bridge/bridge-nf-call-iptables"'
 }
 
 @NonCPS

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -195,12 +195,6 @@ pipeline {
             }
         }
 
-        stage('Pull-Image') {
-            steps {
-                //pullImage()
-            }
-        }
-
         stage('Lint') {
             steps {
                 lint()

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -197,7 +197,7 @@ pipeline {
 
         stage('Pull-Image') {
             steps {
-                pullImage()
+                //pullImage()
             }
         }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -133,17 +133,6 @@ void publishTestResults() {
     archiveArtifacts artifacts: '**/test/test_results/*.xml', allowEmptyArchive: true
 }
 
-void pullImage() {
-    withCredentials([usernamePassword(credentialsId: 'builder-credentials-artifactory', passwordVariable: 'docker_password', usernameVariable: 'docker_user')]) {
-        sh """
-            echo "\$docker_password" | docker login --username \$docker_user --password-stdin ${dockerRegistry}
-            docker pull ${dockerRepository}:${dockerVersion}
-            docker pull ${dockerRepository}:${dockerVersion}
-            docker pull ${dockerRepository}:${prevDockerVersion}
-        """
-    }
-}
-
 String getVersionDiv(mlVersion) {
     switch (mlVersion) {
         case '10.0':

--- a/makefile
+++ b/makefile
@@ -59,6 +59,7 @@ help:
 prepare:
 	go mod tidy
 
+
 #***************************************************************************
 # lint
 #***************************************************************************
@@ -88,11 +89,10 @@ lint:
 .PHONY: e2e-test
 e2e-test: prepare
 	@echo "=====Delete if there are existing minikube cluster"
-	minikube delete
+	minikube delete --all --purge
 
 	@echo "=====Installing minikube cluster"
 	minikube start --driver=docker --kubernetes-version=$(kubernetesVersion) -n=1 --memory=$(minikubeMemory) --cpus=2
-
 
 	@echo "=====Loading marklogc image $(dockerImage) to minikube cluster"
 	minikube image load $(dockerImage)
@@ -114,7 +114,7 @@ e2e-test: prepare
 hc-test: 
  	
 	@echo "=====Delete if there are existing minikube cluster"
-	minikube delete
+	minikube delete --all --purge
 
 	@echo "=====Installing minikube cluster"
 	minikube start --driver=docker --kubernetes-version=$(kubernetesVersion) -n=1 --memory=$(minikubeMemory) --cpus=2


### PR DESCRIPTION
Currently our kubernetes pipeline uses default go context, but the pipeline is running on Jenkins with network user (builder) which is shared. It seems that this can have unintended consequences for the tests as some dependencies could become broken. In addition we should cleanup downloaded dependencies for stability of the pipeline.