### PR TITLE
MLE-13841: compatibility with hostname change

### DIFF
--- a/charts/templates/NOTES.txt
+++ b/charts/templates/NOTES.txt
@@ -16,8 +16,7 @@ WARNING
 FQDN is {{ include "marklogic.fqdn" . }}
 {{- if gt (len (include "marklogic.fqdn" .)) 64 }}
 WARNING:    The hostname is greater than 64 characters
-            There may be issues with certificates
-            The certificates may shorten the name or use SANs for hostnames in the certificates
+            There may be issues with certificates in MarkLogic App Server
 {{- end }}
 
 Group {{ .Values.group.name }} is created on the MarkLogic cluster.

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -15,6 +15,12 @@ terminationGracePeriod: 120
 ## Kubernetes cluster domain name
 clusterDomain: cluster.local
 
+## To allow deployment with hostname over 64 characters
+## This is not remmended as it may cause issues when turning on TLS on MarkLogic Server
+## Because MarkLogic Server only supports using CN as hostname in the certificate
+## There is a limit of 64 characters for CN in the certificate
+allowLongHostname: false
+
 ## Group related settings
 group:
   ## the group name of the current Marklogic Helm Deployment

--- a/makefile
+++ b/makefile
@@ -70,7 +70,7 @@ prepare:
 .PHONY: lint
 lint:
 	@echo "> Linting helm charts....."
-	helm lint --with-subcharts charts/ $(if $(saveOutput),> helm-lint-output.txt,)
+	helm lint --set allowLongHostname=true --with-subcharts charts/ $(if $(saveOutput),> helm-lint-output.txt,)
 
 	@echo "> Linting all tests....."
 	golangci-lint run --timeout=5m $(if $(saveOutput),> test-lint-output.txt,)

--- a/test/template/template_test.go
+++ b/test/template/template_test.go
@@ -155,17 +155,17 @@ func TestAllowLongHostname(t *testing.T) {
 
 	longReleaseName := "very-long-hostname-test-that-should-fail"
 
-	_, error := helm.RenderTemplateE(t, options, helmChartPath, longReleaseName, []string{"templates/statefulset.yaml"})
-	require.Error(t, error, "Expected error due to long release name")
+	_, err = helm.RenderTemplateE(t, options, helmChartPath, longReleaseName, []string{"templates/statefulset.yaml"})
+	require.Error(t, err, "Expected error due to long release name")
 
 	shortReleaseName := "short-hostname"
-	_, error = helm.RenderTemplateE(t, options, helmChartPath, shortReleaseName, []string{"templates/statefulset.yaml"})
-	require.NoError(t, error, "Expected no error due to short release name")
+	_, err = helm.RenderTemplateE(t, options, helmChartPath, shortReleaseName, []string{"templates/statefulset.yaml"})
+	require.NoError(t, err, "Expected no error due to short release name")
 
 	options.SetValues = map[string]string{
 		"allowLongHostname": "true",
 	}
-	_, error = helm.RenderTemplateE(t, options, helmChartPath, longReleaseName, []string{"templates/statefulset.yaml"})
-	require.NoError(t, error, "Expected no error with longReleaseName due to set allowLongHostname to true")
+	_, err = helm.RenderTemplateE(t, options, helmChartPath, longReleaseName, []string{"templates/statefulset.yaml"})
+	require.NoError(t, err, "Expected no error with longReleaseName due to set allowLongHostname to true")
 
 }

--- a/test/template/template_test.go
+++ b/test/template/template_test.go
@@ -137,3 +137,35 @@ func TestTemplatePersistence(t *testing.T) {
 	require.Equal(t, string(statefulset.Spec.VolumeClaimTemplates[1].Spec.AccessModes[0]), additionalVolumeClaimTemplatesAccessModes)
 	require.Equal(t, statefulset.Spec.VolumeClaimTemplates[1].Spec.Resources.Requests.Storage().String(), additionalVolumeClaimTemplatesResourcesRequestsStorage)
 }
+
+func TestAllowLongHostname(t *testing.T) {
+	// Path to the helm chart we will test
+	helmChartPath, err := filepath.Abs("../../charts")
+	require.NoError(t, err)
+
+	// Set up the namespace; confirm that the template renders the expected value for the namespace.
+	namespaceName := "ml-" + strings.ToLower(random.UniqueId())
+	// Setup the args for helm install
+	options := &helm.Options{
+		SetValues: map[string]string{
+			"allowLongHostname": "false",
+		},
+		KubectlOptions: k8s.NewKubectlOptions("", "", namespaceName),
+	}
+
+	longReleaseName := "very-long-hostname-test-that-should-fail"
+
+	_, error := helm.RenderTemplateE(t, options, helmChartPath, longReleaseName, []string{"templates/statefulset.yaml"})
+	require.Error(t, error, "Expected error due to long release name")
+
+	shortReleaseName := "short-hostname"
+	_, error = helm.RenderTemplateE(t, options, helmChartPath, shortReleaseName, []string{"templates/statefulset.yaml"})
+	require.NoError(t, error, "Expected no error due to short release name")
+
+	options.SetValues = map[string]string{
+		"allowLongHostname": "true",
+	}
+	_, error = helm.RenderTemplateE(t, options, helmChartPath, longReleaseName, []string{"templates/statefulset.yaml"})
+	require.NoError(t, error, "Expected no error with longReleaseName due to set allowLongHostname to true")
+
+}


### PR DESCRIPTION
1. When install with Helm 1.1.2 and upgrade from 1.1.x, use short name. When upgrade from 1.0.x, use the original long name. (don’t change the name).

2. Introduce allowLongHostname parameter, default to false. When set to true, Allow upgrade from 1.0.x with hostname longer than 64.  

3. Update Notes.txt to give warning when hostname longer than 64.

4. Template Test for allowLongHostname.