### PR TITLE
Bug fix for 1.1.2 release

### DIFF
--- a/charts/templates/_helpers.tpl
+++ b/charts/templates/_helpers.tpl
@@ -37,11 +37,15 @@ oldFullname is the name used before 1.1.x release
 {{- if .Release.IsInstall -}}
 {{- true }}
 {{- else }}
+{{- if .Values.fullnameOverride  -}}
+{{- false }}
+{{- else }}
 {{- $newCm := (lookup "apps/v1" "StatefulSet" .Release.Namespace (include "marklogic.newFullname" .)) }}
 {{- if $newCm  }}
 {{- true }}
 {{- else }}
 {{- false }}
+{{- end }}
 {{- end }}
 {{- end }}
 {{- end }}
@@ -75,6 +79,20 @@ Create headless service name for statefulset
 {{- include "marklogic.newFullname" . }}
 {{- else }}
 {{- printf "%s-headless" (include "marklogic.oldFullname" .) }}
+{{- end }}
+{{- end }}
+{{/*
+{{- end}}
+
+
+{{/*
+Create cluster service name for statefulset
+*/}}
+{{- define "marklogic.clusterServiceName" -}}
+{{- if eq (include "marklogic.shouldUseNewName" .) "true" -}}
+{{- include "marklogic.newFullname" . }}-cluster
+{{- else }}
+{{- include "marklogic.oldFullname" . }}
 {{- end }}
 {{- end }}
 {{/*

--- a/charts/templates/_helpers.tpl
+++ b/charts/templates/_helpers.tpl
@@ -9,18 +9,27 @@ Expand the name of the chart.
 newFullname is the name used after 1.1.x release, in an effort to make the release name shorter.
 */}}
 {{- define "marklogic.newFullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
 {{- .Release.Name | trunc 63 | trimSuffix "-" }}
 {{- end }}
+{{- end }}
+
 
 {{/* 
 oldFullname is the name used before 1.1.x release
 */}}
 {{- define "marklogic.oldFullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
 {{- $name := default .Chart.Name .Values.nameOverride }}
 {{- if contains $name .Release.Name }}
 {{- .Release.Name | trunc 63 | trimSuffix "-" }}
 {{- else }}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
 {{- end }}
 {{- end }}
 
@@ -44,14 +53,10 @@ To surrport the upgrade from 1.0.x to 1.1.x, we keep the old name when doing upg
 For the new install, we use the new name, which is the release name.
 */}}
 {{- define "marklogic.fullname" -}}
-{{- if .Values.fullnameOverride }}
-{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
-{{- else }}
 {{- if eq (include "marklogic.shouldUseNewName" .) "true" -}}
 {{- include "marklogic.newFullname" . }}
 {{- else }}
 {{- include "marklogic.oldFullname" . }}
-{{- end }}
 {{- end }}
 {{- end }}
 

--- a/charts/templates/configmap-haproxy.yaml
+++ b/charts/templates/configmap-haproxy.yaml
@@ -81,7 +81,7 @@ data:
         mode tcp
         balance leastconn
         {{- range $i := until $replicas }}
-        server {{ printf "ml-%s-%s-%v" $releaseName $portNumber $i }} {{ $releaseName }}-{{ $i }}.{{ $releaseName }}.{{ $namespace }}.svc.{{ $clusterDomain }}:{{ $portNumber }} check resolvers dns init-addr none
+        server {{ printf "ml-%s-%s-%v" $releaseName $portNumber $i }} {{ $releaseName }}-{{ $i }}.{{ $headlessServiceName }}.{{ $namespace }}.svc.{{ $clusterDomain }}:{{ $portNumber }} check resolvers dns init-addr none
         {{- end }}
     {{- else if eq $portType "HTTP" }}
 

--- a/charts/templates/service.yaml
+++ b/charts/templates/service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "marklogic.fullname" . }}-cluster
+  name: {{ include "marklogic.clusterServiceName" . }}
   namespace: {{ .Values.namespace}}
   labels:
     {{- include "marklogic.labels" . | nindent 4 }}


### PR DESCRIPTION
1. make oldFullname use fullnameOverride if it is set
2. Change the TCP port to use headlessServiceName
3. keep the name of the cluster service the same