### PR TITLE
MLE-13757 fix hc tests

### DIFF
--- a/test/hc_e2e.sh
+++ b/test/hc_e2e.sh
@@ -27,7 +27,8 @@ sleep 10
 
 echo "---- start UI sanity tests on HC ----"
 cd marklogic-data-hub-central/ui/e2e
-npm run cy:run --reporter junit --reporter-options "toConsole=false"
+npm install
+npm run cy:run-sanity --reporter junit --reporter-options "toConsole=false"
 
 echo "---- cleanup resources ----"
 kill $bootRunPID $forwarderPID


### PR DESCRIPTION
We'll run only sanity tests on HC instead of full e2e suite which should be more stable.
As a bonus the tests will only take about 20 minutes instead of 1.5 hours!