### PR TITLE
Kubernetes 1.1.2 Bug Fix

### DIFF
--- a/charts/templates/_helpers.tpl
+++ b/charts/templates/_helpers.tpl
@@ -60,7 +60,7 @@ oldFullname is the name used before 1.1.x release
 {{- $chartVersionString := $chartVersionWithDot | replace "." "" }}
 {{- $chartVersionDigit := int $chartVersionString }}
 {{- if lt $chartVersionDigit 110 -}}
-{{- $errorMessage := printf "New hostnames has been introduced since version 1.1.0. You are upgrading from version %s to version %s. To make the upgrade successful, please set the following configuration in values file to keep using the legacy hostname: \n\nuseLegacyHostnames: true\n" $chartVersionWithDot .Chart.Version }}
+{{- $errorMessage := printf "A new algorithm for generating hostnames was introduced in version 1.1.0. When upgrading from version %s to version %s, the \"useLegacyHostnames\" setting must be set to true to prevent the StatefulSet from being recreated. Please add the following to the values file and attempt the upgrade again: \n\nuseLegacyHostnames: true\n" $chartVersionWithDot .Chart.Version }}
 {{- fail $errorMessage }}
 {{- end }}
 {{- end }}

--- a/charts/templates/configmap-scripts.yaml
+++ b/charts/templates/configmap-scripts.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ .Release.Name }}-scripts
+  name: {{ include "marklogic.fullname" . }}-scripts
 data:
   liveness-probe.sh: |
     #!/bin/bash

--- a/charts/templates/statefulset.yaml
+++ b/charts/templates/statefulset.yaml
@@ -318,40 +318,39 @@ spec:
                       [ -f /var/opt/MarkLogic/group_cfg ] && current_group_cfg=$(cat /var/opt/MarkLogic/group_cfg)
                       if [ "${MARKLOGIC_GROUP}:${XDQP_SSL_ENABLED}:${MARKLOGIC_JOIN_TLS_ENABLED}" = "${current_group_cfg}" ] || 
                         [ "${MARKLOGIC_GROUP}:${XDQP_SSL_ENABLED}" = "${current_group_cfg}" ]; then
-                          log "Info: [poststart] Group config has not changed, poststart hook complete"
-                          exit 0
-                      fi
+                          log "Info: [poststart] Group config has not changed, skip group configuration"
+                      else 
+                        log "Info: [poststart] Begin group configuration."
+                        while [ ! -f /var/opt/MarkLogic/ready ]; do
+                          log "[poststart] waiting for MarkLogic server to be ready"
+                          sleep 5s
+                        done
 
-                      log "Info: [poststart] Begin group configuration."
-                      while [ ! -f /var/opt/MarkLogic/ready ]; do
-                        log "[poststart] waiting for MarkLogic server to be ready"
-                        sleep 5s
-                      done
+                        GROUP_CFG_TEMPLATE='{"group-name":"%s", "xdqp-ssl-enabled":"%s"}'
+                        GROUP_CFG=$(printf "$GROUP_CFG_TEMPLATE" "$MARKLOGIC_GROUP" "$XDQP_SSL_ENABLED")
 
-                      GROUP_CFG_TEMPLATE='{"group-name":"%s", "xdqp-ssl-enabled":"%s"}'
-                      GROUP_CFG=$(printf "$GROUP_CFG_TEMPLATE" "$MARKLOGIC_GROUP" "$XDQP_SSL_ENABLED")
-
-                      log "Info: [poststart] Updating group configuration: ${GROUP_CFG}"
-                      GROUP_RESP_CODE=`curl --retry 5 --retry-max-time 60 -o /tmp/restart_payload.xml -w "%{http_code}" --anyauth -m 20 -s -X PUT -H "Content-type: application/json" -d "${GROUP_CFG}" http://${MARKLOGIC_BOOTSTRAP_HOST}:8002/manage/v2/groups/Default/properties --user ${MARKLOGIC_ADMIN_USERNAME}:${MARKLOGIC_ADMIN_PASSWORD}`
-                    
-                      # check whether MarkLogic has restarted
-                      if [[ ${GROUP_RESP_CODE} -eq 202 ]] || [[ ${GROUP_RESP_CODE} -eq 204 ]]; then
-                        log "Info: [poststart] Successfully configured properties for $MARKLOGIC_GROUP group on the MarkLogic cluster."
-                        TIMESTAMP=$(< /tmp/restart_payload.xml grep "last-startup" | sed 's%^.*<last-startup.*>\(.*\)</last-startup>.*$%\1%')
-                        rm  -f /tmp/restart_payload.xml
-                        if [[ -n ${TIMESTAMP} ]]; then
-                          restart_check ${TIMESTAMP}
-                        fi
-                        if [[ $MARKLOGIC_IMAGE_TYPE == "rootless" ]]; then
-                          sh -c 'echo -n '"${MARKLOGIC_GROUP}:${XDQP_SSL_ENABLED}:${MARKLOGIC_JOIN_TLS_ENABLED}"' > /var/opt/MarkLogic/group_cfg'
+                        log "Info: [poststart] Updating group configuration: ${GROUP_CFG}"
+                        GROUP_RESP_CODE=`curl --retry 5 --retry-max-time 60 -o /tmp/restart_payload.xml -w "%{http_code}" --anyauth -m 20 -s -X PUT -H "Content-type: application/json" -d "${GROUP_CFG}" http://${MARKLOGIC_BOOTSTRAP_HOST}:8002/manage/v2/groups/Default/properties --user ${MARKLOGIC_ADMIN_USERNAME}:${MARKLOGIC_ADMIN_PASSWORD}`
+                      
+                        # check whether MarkLogic has restarted
+                        if [[ ${GROUP_RESP_CODE} -eq 202 ]] || [[ ${GROUP_RESP_CODE} -eq 204 ]]; then
+                          log "Info: [poststart] Successfully configured properties for $MARKLOGIC_GROUP group on the MarkLogic cluster."
+                          TIMESTAMP=$(< /tmp/restart_payload.xml grep "last-startup" | sed 's%^.*<last-startup.*>\(.*\)</last-startup>.*$%\1%')
+                          rm  -f /tmp/restart_payload.xml
+                          if [[ -n ${TIMESTAMP} ]]; then
+                            restart_check ${TIMESTAMP}
+                          fi
+                          if [[ $MARKLOGIC_IMAGE_TYPE == "rootless" ]]; then
+                            sh -c 'echo -n '"${MARKLOGIC_GROUP}:${XDQP_SSL_ENABLED}:${MARKLOGIC_JOIN_TLS_ENABLED}"' > /var/opt/MarkLogic/group_cfg'
+                          else
+                            sudo sh -c 'echo -n '"${MARKLOGIC_GROUP}:${XDQP_SSL_ENABLED}:${MARKLOGIC_JOIN_TLS_ENABLED}"' > /var/opt/MarkLogic/group_cfg'
+                          fi
+                          log "Info: [poststart] ${GROUP_CFG} saved"
                         else
-                          sudo sh -c 'echo -n '"${MARKLOGIC_GROUP}:${XDQP_SSL_ENABLED}:${MARKLOGIC_JOIN_TLS_ENABLED}"' > /var/opt/MarkLogic/group_cfg'
+                          log "Error: [poststart] Failed to configure properties for $MARKLOGIC_GROUP group.
+                          log "Error: [poststart] Expected response code 202 or 204, got "${GROUP_RESP_CODE}"
+                          exit 1
                         fi
-                        log "Info: [poststart] ${GROUP_CFG} saved"
-                      else
-                        log "Error: [poststart] Failed to configure properties for $MARKLOGIC_GROUP group.
-                        log "Error: [poststart] Expected response code 202 or 204, got "${GROUP_RESP_CODE}"
-                        exit 1
                       fi
                     else
                       log "Info: [poststart] This is not bootstrap host. Skipping group configuration."

--- a/charts/templates/statefulset.yaml
+++ b/charts/templates/statefulset.yaml
@@ -661,7 +661,7 @@ spec:
             secretName: {{ include "marklogic.authSecretNameToMount" . }}
         - name: scripts
           configMap:
-            name: {{ .Release.Name }}-scripts
+            name: {{ include "marklogic.fullname" . }}-scripts
             defaultMode: 0755
         {{- if .Values.logCollection.enabled }}
         - name: {{ include "marklogic.fullname" . }}-fb-config-map

--- a/charts/templates/statefulset.yaml
+++ b/charts/templates/statefulset.yaml
@@ -316,7 +316,12 @@ spec:
                     # Begin Group Configuration
                     if [[ $POD_NAME == *-0 ]] && [[ $MARKLOGIC_CLUSTER_TYPE == "bootstrap" ]]; then
                       [ -f /var/opt/MarkLogic/group_cfg ] && current_group_cfg=$(cat /var/opt/MarkLogic/group_cfg)
-                      if [ "${MARKLOGIC_GROUP}:${XDQP_SSL_ENABLED}:${MARKLOGIC_JOIN_TLS_ENABLED}" = "${current_group_cfg}" ] || 
+                      colon_count=$(echo "$current_group_cfg" | awk -F':' '{print NF-1}')
+                      if [ "$colon_count" -eq 2 ]; then
+                        current_group_cfg="${current_group_cfg%:*}"
+                      fi
+                      if [ "${MARKLOGIC_GROUP}:${XDQP_SSL_ENABLED}:true" = "${current_group_cfg}" ] || 
+                          [ "${MARKLOGIC_GROUP}:${XDQP_SSL_ENABLED}:false" = "${current_group_cfg}" ] ||
                         [ "${MARKLOGIC_GROUP}:${XDQP_SSL_ENABLED}" = "${current_group_cfg}" ]; then
                           log "Info: [poststart] Group config has not changed, skip group configuration"
                       else 
@@ -341,9 +346,9 @@ spec:
                             restart_check ${TIMESTAMP}
                           fi
                           if [[ $MARKLOGIC_IMAGE_TYPE == "rootless" ]]; then
-                            sh -c 'echo -n '"${MARKLOGIC_GROUP}:${XDQP_SSL_ENABLED}:${MARKLOGIC_JOIN_TLS_ENABLED}"' > /var/opt/MarkLogic/group_cfg'
+                            sh -c 'echo -n '"${MARKLOGIC_GROUP}:${XDQP_SSL_ENABLED}"' > /var/opt/MarkLogic/group_cfg'
                           else
-                            sudo sh -c 'echo -n '"${MARKLOGIC_GROUP}:${XDQP_SSL_ENABLED}:${MARKLOGIC_JOIN_TLS_ENABLED}"' > /var/opt/MarkLogic/group_cfg'
+                            sudo sh -c 'echo -n '"${MARKLOGIC_GROUP}:${XDQP_SSL_ENABLED}"' > /var/opt/MarkLogic/group_cfg'
                           fi
                           log "Info: [poststart] ${GROUP_CFG} saved"
                         else

--- a/charts/templates/statefulset.yaml
+++ b/charts/templates/statefulset.yaml
@@ -320,9 +320,7 @@ spec:
                       if [ "$colon_count" -eq 2 ]; then
                         current_group_cfg="${current_group_cfg%:*}"
                       fi
-                      if [ "${MARKLOGIC_GROUP}:${XDQP_SSL_ENABLED}:true" = "${current_group_cfg}" ] || 
-                          [ "${MARKLOGIC_GROUP}:${XDQP_SSL_ENABLED}:false" = "${current_group_cfg}" ] ||
-                        [ "${MARKLOGIC_GROUP}:${XDQP_SSL_ENABLED}" = "${current_group_cfg}" ]; then
+                      if [ "${MARKLOGIC_GROUP}:${XDQP_SSL_ENABLED}" = "${current_group_cfg}" ]; then
                           log "Info: [poststart] Group config has not changed, skip group configuration"
                       else 
                         log "Info: [poststart] Begin group configuration."
@@ -366,7 +364,7 @@ spec:
                       https_error_message="You have attempted to access an HTTPS server using HTTP."
                       resp=$(curl -s http://localhost:8001)
                       if [[ "$resp" == *"$https_error_message"* ]]; then
-                          log "Info: [poststart] MarkLogic server has already configured HTTPS"
+                        log "Info: [poststart] MarkLogic server has already configured HTTPS"
                         exit 0
                       else 
                         log "Info: [poststart] MARKLOGIC_JOIN_TLS_ENABLED is set to true, configuring SSL"


### PR DESCRIPTION
1. MLE-14200: Updated error message when upgrade from 1.0.2 without setting enableOnDefaultAppServers
2. MLE-14114: Fix bug when upgrade from 1.0.2 and 1.1.1 TLS turned on does not work
3. Change the name for script configmap from .Release.Name to .marklogic.fullname, which is the name for all the other resources.