### PR TITLE
MLE-14608 Update K8s versions

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -180,7 +180,7 @@ pipeline {
         choice(name: 'dockerImageType', choices: 'ubi-rootless\nubi\ncentos', description: 'Platform type for Docker image')
         string(name: 'dockerVersion', defaultValue: 'latest-11', description: 'Docker tag to use for tests. (e.g. 11.2.nightly-ubi-rootless-1.1.2) Has to correspond with dockerImageType.', trim: true)
         string(name: 'prevDockerVersion', defaultValue: 'latest-10', description: 'Previous Docker version for MarkLogic upgrade tests. (e.g. 10.0-10.2-centos-1.1.2) Has to correspond with dockerImageType.', trim: true)
-        choice(name: 'K8_VERSION', choices: 'v1.29.6\nv1.30.2\nv1.28.11\nv1.27.15\nv1.26.15\nv1.25.16\nv1.24.17', description: 'Test Kubernetes version.')
+        choice(name: 'K8_VERSION', choices: 'v1.29.6\nv1.30.2\nv1.28.11\nv1.27.15\nv1.26.15\nv1.25.16', description: 'Test Kubernetes version.')
         booleanParam(name: 'KUBERNETES_TESTS', defaultValue: true, description: 'Run kubernetes tests')
         string(name: 'KUBERNETES_TEST_SELECTION', defaultValue: '...', description: 'Pick one test to run. (e.g. tls_test.go) ... will run all tests.', trim: true)
         booleanParam(name: 'HC_TESTS', defaultValue: false, description: 'Run Hub Central E2E UI tests (takes about 3 hours)')


### PR DESCRIPTION
- add local install of go linter and test runner
- update k8s versions
- use global paths instead of a bunch of exports