### PR TITLE
MLE-21296 set-automountServiceAccountToken-to-false

### DIFF
--- a/charts/templates/statefulset.yaml
+++ b/charts/templates/statefulset.yaml
@@ -63,6 +63,8 @@ spec:
       securityContext: {{- omit .Values.podSecurityContext "enabled" | toYaml | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "marklogic.serviceAccountName" . }}
+      automountServiceAccountToken: false
+      {{- if .Values.tolerations }}
       {{- with .Values.affinity }}
       affinity: {{- toYaml . | nindent 8}}
       {{- end }}

--- a/charts/templates/statefulset.yaml
+++ b/charts/templates/statefulset.yaml
@@ -64,7 +64,6 @@ spec:
       {{- end }}
       serviceAccountName: {{ include "marklogic.serviceAccountName" . }}
       automountServiceAccountToken: false
-      {{- if .Values.tolerations }}
       {{- with .Values.affinity }}
       affinity: {{- toYaml . | nindent 8}}
       {{- end }}


### PR DESCRIPTION
As a Kubernetes admin and MarkLogic admin,

I want to have automountServiceAccountToken set to false. This will allow to add more security.