### PR TITLE
MLE-28393: Upgrade haproxy image tag from 3.2.1 to 3.2.15

### DIFF
--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -350,7 +350,7 @@ haproxy:
   enabled: false
   image:
     repository: haproxytech/haproxy-alpine
-    tag: "3.2.1"
+    tag: "3.2.15"
     pullPolicy: IfNotPresent
 
   ## Name of an existing configmap with configuration for HAProxy


### PR DESCRIPTION
## Summary

Upgrades the haproxy container image tag in `charts/values.yaml` from `3.2.1` to `3.2.15`.

## Root cause

The haproxy image tag in `charts/values.yaml` was pinned to `3.2.1`, which is an outdated patch of the 3.2 LTS branch. Version `3.2.15` is the latest patch as of April 2026, containing security and stability fixes.

## Fix

Updated `charts/values.yaml`:

```
haproxy.image.tag: "3.2.1" -> "3.2.15"
```

The repository (`haproxytech/haproxy-alpine`) and pull policy are unchanged.

## Validation

- Helm lint (`helm lint --set allowLongHostnames=true --with-subcharts charts/`) passes with 0 failures.
- Jenkins PR builds pending: auto-triggered build will cover `ubi-rootless + latest-11`; manual trigger required for `ubi9 + latest-12`.

## Jira

https://progresssoftware.atlassian.net/browse/MLE-28393