### PR TITLE
MLE-27322: clean up temporary test framework files in post-build stage

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -262,6 +262,7 @@ pipeline {
                 docker volume prune --force --all
                 docker system df
                 sudo rm -rf /space/minikube/ /space/go /space/.kube-config
+                sudo rm -rf /tmp/k8s_test_framework_*
             '''
             sh "rm -rf $WORKSPACE/test/test_results/"
         }


### PR DESCRIPTION
## Summary

Root cause: The terratest k8s library creates temporary kubeconfig files under `/tmp/k8s_test_framework_*` during test runs and does not clean them up. These accumulate across builds and can exhaust disk space on the build agent.

Fix: Add `sudo rm -rf /tmp/k8s_test_framework_*` to the `post { always }` cleanup block in the Jenkinsfile, alongside the existing agent cleanup steps.

## Validation

- Helm lint: passed (0 charts failed)
- No chart or Go source changes; Jenkins build will validate the pipeline stage ordering